### PR TITLE
Fall back to `load_type` property if `loadType` is not present

### DIFF
--- a/Example/Tests/Segment_Nielsen_DTVR_ExampleTests.m
+++ b/Example/Tests/Segment_Nielsen_DTVR_ExampleTests.m
@@ -96,6 +96,25 @@ describe(@"SEGNielsenDTVRIntegration", ^{
                                                       @"adModel": @""
                                                       }];
         });
+
+        it(@"tracks loadMetadata properly with key loadType", ^{
+            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Content Started"
+                                                                   properties:@{
+                                                                                @"asset_id" : @"1234",
+                                                                                @"channel": @"defaultChannelName",
+                                                                                @"loadType": @"linear"
+                                                                                }
+                                                                      context:@{}
+                                                                 integrations:@{}
+                                        ];
+            [integration track:payload];
+            
+            [verify(mockNielsenAppApi) loadMetadata:@{
+                                                      @"channelName" : @"defaultChannelName",
+                                                      @"type": @"content",
+                                                      @"adModel": @"1"
+                                                      }];
+        });
     });
     
     

--- a/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegration.m
+++ b/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegration.m
@@ -100,7 +100,13 @@
                                            withHandler:^void (NielsenAppApi *nielsen, SEGTrackPayload *payload) {
                                                NSDictionary *properties = payload.properties;
                                                
-                                               NSString *loadType = properties[@"load_type"];
+                                               NSString *value;
+                                               if ([properties valueForKey:"@loadType"]) {
+                                                   value = [properties valueForKey:"@loadType"]
+                                               } else if (properties valueForKey:"@load_type"]) {
+                                                   value = properties valueForKey:"@load_type"]
+                                               }
+                                               
                                                NSString *adModel;
                                                if ([loadType isEqualToString:@"linear"]) {
                                                    adModel = @"1";


### PR DESCRIPTION
Here's the passing CI test we care about right now: https://circleci.com/gh/segment-integrations/analytics-ios-integration-nielsen-dtvr/32?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

This PR falls back to look for a `load_type` property if `loadType` does not exist. This PR ensures that all of our Nielsen SDKs (Android DTVR, Android DCR, iOS DTVR, and iOS DCR) have parity with regard to this feature - now all SDKs first look for `loadType`, then fall back to `load_type` if the former is not present in `event.properties`.

Once this is merged, I will push a release commit to master, then push tags to release a new version of the SDK.