### PR TITLE
Fix loadType-related error.

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - OCHamcrest (7.1.1)
   - OCMockito (5.1.1):
     - OCHamcrest (~> 7.0)
-  - Segment-Nielsen-DTVR (0.0.1):
+  - Segment-Nielsen-DTVR (0.0.4-beta):
     - Analytics (~> 3.6)
   - Specta (1.0.7)
 
@@ -36,9 +36,9 @@ SPEC CHECKSUMS:
   NielsenAppSDK: be0732f26810c30d4353148d433cfe9da4bf2f96
   OCHamcrest: 3506736397451c35d8763ff0a9b13492e544115f
   OCMockito: eccb29c256cbdd6c7bc206718cbb06ef737daa8b
-  Segment-Nielsen-DTVR: 7b78b47054b004677dcb13410887dc7929ba8457
+  Segment-Nielsen-DTVR: 3cab287baec55b6331258717c9da9aa906c25b3e
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
 PODFILE CHECKSUM: b37d1148056847512fd82a5479f612bda8199e1c
 
-COCOAPODS: 1.7.3
+COCOAPODS: 1.7.5

--- a/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegration.m
+++ b/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegration.m
@@ -101,17 +101,17 @@
                                                NSDictionary *properties = payload.properties;
                                                
                                                NSString *value;
-                                               if ([properties valueForKey:"@loadType"]) {
-                                                   value = [properties valueForKey:"@loadType"]
-                                               } else if (properties valueForKey:"@load_type"]) {
-                                                   value = properties valueForKey:"@load_type"]
+                                               if ([properties valueForKey:@"loadType"]) {
+                                                   value = [properties valueForKey:@"loadType"];
+                                               } else if ([properties valueForKey:@"load_type"]) {
+                                                   value = [properties valueForKey:@"load_type"];
                                                }
                                                
                                                NSString *adModel;
-                                               if ([loadType isEqualToString:@"linear"]) {
+                                               if ([value isEqualToString:@"linear"]) {
                                                    adModel = @"1";
                                                }
-                                               else if([loadType isEqualToString:@"dynamic"]) {
+                                               else if([value isEqualToString:@"dynamic"]) {
                                                    adModel = @"2";
                                                }
                                                


### PR DESCRIPTION
This PR fixes an issue that prevented the Segment-Nielsen DTVR SDK from compiling due to incorrect syntax. I'm not entirely sure why tests didn't catch the issue.

Here, however, I have tested locally and the SDK does compile, and I'm able to view a video in the Sample App provided in this repo without any errors or app crashes.