### PR TITLE
[DEST-1176] Update Makefile and Circle Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build_and_test:
     macos:
-      xcode: "9.4.1"
+      xcode: "11.0"
     steps:
       - checkout
       - run: xcrun simctl list

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - OCHamcrest (7.1.1)
   - OCMockito (5.1.1):
     - OCHamcrest (~> 7.0)
-  - Segment-Nielsen-DTVR (0.0.4-beta):
+  - Segment-Nielsen-DTVR (0.0.4):
     - Analytics (~> 3.6)
   - Specta (1.0.7)
 
@@ -36,7 +36,7 @@ SPEC CHECKSUMS:
   NielsenAppSDK: be0732f26810c30d4353148d433cfe9da4bf2f96
   OCHamcrest: 3506736397451c35d8763ff0a9b13492e544115f
   OCMockito: eccb29c256cbdd6c7bc206718cbb06ef737daa8b
-  Segment-Nielsen-DTVR: 3cab287baec55b6331258717c9da9aa906c25b3e
+  Segment-Nielsen-DTVR: 2a359c66be5409ae2b2e9fd7fe7f7852812594a1
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
 PODFILE CHECKSUM: b37d1148056847512fd82a5479f612bda8199e1c

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-XCPRETTY := xcpretty -c &&
+XCPRETTY := xcpretty -c
 
 SDK ?= "iphonesimulator"
 DESTINATION ?= "platform=iOS Simulator,name=iPhone 8"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-XCPRETTY := xcpretty -c && exit ${PIPESTATUS[0]}
+XCPRETTY := xcpretty -c &&
 
 SDK ?= "iphonesimulator"
-DESTINATION ?= "platform=iOS Simulator,name=iPhone 7"
+DESTINATION ?= "platform=iOS Simulator,name=iPhone 8"
 PROJECT := Segment-Nielsen-DTVR
 XC_ARGS := -scheme $(PROJECT)_Example -workspace Example/$(PROJECT).xcworkspace -sdk $(SDK) -destination $(DESTINATION) ONLY_ACTIVE_ARCH=NO
 
@@ -13,9 +13,15 @@ clean:
 	xcodebuild $(XC_ARGS) clean | $(XCPRETTY)
 
 build:
+	xcodebuild $(XC_ARGS)
+
+build-dev:
 	xcodebuild $(XC_ARGS) | $(XCPRETTY)
 
 test:
+	xcodebuild test $(XC_ARGS)
+
+test-dev:
 	xcodebuild test $(XC_ARGS) | $(XCPRETTY)
 
 lint:
@@ -27,5 +33,5 @@ xcbuild:
 xctest:
 	xctool test $(XC_ARGS)
 
-.PHONY: test build xctest xcbuild clean
+.PHONY: test test-dev build build-dev xctest xcbuild clean
 .SILENT:


### PR DESCRIPTION
https://segment.atlassian.net/browse/DEST-1176

This PR updates the repo's Makefile and Circle config so that Circle properly reports when jobs have passed or failed. Previously, Circle would mark all jobs as passing, as the exit code for various make commands was not properly exposed. Now, all exit codes should be properly exposed, and Circle will fail on `build` and `test` if something is wrong.

This update does not require a CC ticket as it does not alter the functionality of the SDK. In addition, we won't cut a new release since these are just internal tooling changes.