### PR TITLE
Remove version pinning

### DIFF
--- a/Segment-Nielsen-DTVR.podspec
+++ b/Segment-Nielsen-DTVR.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name          = 'Segment-Nielsen-DTVR'
-    s.version       = '0.0.4'
+    s.version       = '0.0.5'
     s.summary       = 'Nielsen DTVR Integration for Segment'
     s.description   = <<-DESC
     Analytics for iOS. This is the Nielsen DTVR integration for the iOS library.
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
     s.social_media_url  = 'https://twitter.com/segment'
     s.ios.deployment_target = '8.0'
     s.preserve_paths = 'Segment-Nielsen-DTVR/Classes/**/*'
-    s.dependency 'Analytics', '~> 3.6'
+    s.dependency 'Analytics'
 end


### PR DESCRIPTION
The version pinning on Nielsen DTVR is blocking Fox from updating to the latest ios library (4.0.1). which is necessary for them to resolve other open issues. It also restricts them from using new features like destinationMiddlewares in analytics-ios 4.x. This is high urgency for Fox. Please let me know if any testing is needed to merge this and I can do so!