### PR TITLE
[STRATCONN-420] Update imports

### DIFF
--- a/Example/Segment-Nielsen-DTVR_Example/SEGNielsenMainViewController.m
+++ b/Example/Segment-Nielsen-DTVR_Example/SEGNielsenMainViewController.m
@@ -6,12 +6,12 @@
 //
 
 #import <AVKit/AVPlayerViewController.h>
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGAnalytics.h>
 #else
 #import <Segment/SEGAnalytics.h>
 #endif
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegrationsManager.h>
 #else
 #import <Segment/SEGIntegrationsManager.h>

--- a/Example/Segment-Nielsen-DTVR_Example/SEGNielsenMainViewController.m
+++ b/Example/Segment-Nielsen-DTVR_Example/SEGNielsenMainViewController.m
@@ -8,12 +8,9 @@
 #import <AVKit/AVPlayerViewController.h>
 #if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGAnalytics.h>
-#else
-#import <Segment/SEGAnalytics.h>
-#endif
-#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegrationsManager.h>
 #else
+#import <Segment/SEGAnalytics.h>
 #import <Segment/SEGIntegrationsManager.h>
 #endif
 #import "SEGNielsenDTVRIntegrationFactory.h"

--- a/Example/Segment-Nielsen-DTVR_Example/SEGNielsenMainViewController.m
+++ b/Example/Segment-Nielsen-DTVR_Example/SEGNielsenMainViewController.m
@@ -6,8 +6,16 @@
 //
 
 #import <AVKit/AVPlayerViewController.h>
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGAnalytics.h>
+#else
+#import <Segment/SEGAnalytics.h>
+#endif
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGIntegrationsManager.h>
+#else
+#import <Segment/SEGIntegrationsManager.h>
+#endif
 #import "SEGNielsenDTVRIntegrationFactory.h"
 #import "SEGNielsenDTVRIntegration.h"
 #import "SEGVideoModel.h"

--- a/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegration.h
+++ b/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegration.h
@@ -6,7 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegration.h>
 #else
 #import <Segment/SEGIntegration.h>

--- a/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegration.h
+++ b/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegration.h
@@ -6,7 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGIntegration.h>
+#else
+#import <Segment/SEGIntegration.h>
+#endif
 #import <NielsenAppApi/NielsenAppApi.h>
 
 @interface SEGNielsenDTVRIntegration : NSObject <SEGIntegration>

--- a/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegrationFactory.h
+++ b/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegrationFactory.h
@@ -6,7 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegrationFactory.h>
 #else
 #import <Segment/SEGIntegrationFactory.h>

--- a/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegrationFactory.h
+++ b/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegrationFactory.h
@@ -6,7 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGIntegrationFactory.h>
+#else
+#import <Segment/SEGIntegrationFactory.h>
+#endif
 
 @interface SEGNielsenDTVRIntegrationFactory : NSObject <SEGIntegrationFactory>
 

--- a/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegrationFactory.m
+++ b/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegrationFactory.m
@@ -7,12 +7,12 @@
 
 #import "SEGNielsenDTVRIntegrationFactory.h"
 #import "SEGNielsenDTVRIntegration.h"
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegration.h>
 #else
 #import <Segment/SEGIntegration.h>
 #endif
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGAnalytics.h>
 #else
 #import <Segment/SEGAnalytics.h>

--- a/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegrationFactory.m
+++ b/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegrationFactory.m
@@ -7,8 +7,16 @@
 
 #import "SEGNielsenDTVRIntegrationFactory.h"
 #import "SEGNielsenDTVRIntegration.h"
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGIntegration.h>
+#else
+#import <Segment/SEGIntegration.h>
+#endif
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGAnalytics.h>
+#else
+#import <Segment/SEGAnalytics.h>
+#endif
 
 @interface SEGNielsenDTVRIntegrationFactory()
 

--- a/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegrationFactory.m
+++ b/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegrationFactory.m
@@ -9,12 +9,9 @@
 #import "SEGNielsenDTVRIntegration.h"
 #if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegration.h>
-#else
-#import <Segment/SEGIntegration.h>
-#endif
-#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGAnalytics.h>
 #else
+#import <Segment/SEGIntegration.h>
 #import <Segment/SEGAnalytics.h>
 #endif
 


### PR DESCRIPTION
https://paper.dropbox.com/doc/PRD-Analytics-iOS-Namespace-Change--A89lGjxWJiMUgRtRmVL5aN1UAg-FewzU7P1dJM5yKVEgfenA

Segment’s iOS SDK was namespaced to SEGAnalytics under the Objective-C naming convention. As we modernized the SDK to support Swift and more package managers beyond Cocoapods such as Swift Package Manager and Carthage the namespace was renamed to Analytics in-line with Swift idioms as well as Package Manager requirements. It was released as beta. We have received customer feedback that this is leading to namespace collisions and are now going to change this to a much clearer namespace: Segment and the community prefer this as well.