### PR TITLE
update mapping for Video Playback Completed and add mapping for Video Playback Exited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Version 1.0.1 *(7th April, 2021)*
+-------------------------------------------
+* Updates `Video Playback Completed` to call `stop`.
+* Maps `Video Playback Exited` to call `stop` .
+* Removes `end` handler as per Nielsen's requirements to use `stop` instead.
+
 Version 1.0.0 *(13th November, 2020)*
 -------------------------------------------
 * Updates Nielsen SDK to 8.x

--- a/Example/Tests/Segment_Nielsen_DTVR_ExampleTests.m
+++ b/Example/Tests/Segment_Nielsen_DTVR_ExampleTests.m
@@ -260,7 +260,22 @@ describe(@"SEGNielsenDTVRIntegration", ^{
         
         [integration track:payload];
         
-        [(NielsenAppApi *)verify(mockNielsenAppApi) end];
+        [(NielsenAppApi *)verify(mockNielsenAppApi) stop];
+    });
+    
+    it(@"tracks Video Playback Exited", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Playback Exited"
+                                                               properties:@{
+                                                                            @"asset_id" : @"1234",
+                                                                            @"channel": @"defaultChannelName",
+                                                                            }
+                                                                  context:@{}
+                                                             integrations:@{}
+                                    ];
+        
+        [integration track:payload];
+        
+        [(NielsenAppApi *)verify(mockNielsenAppApi) stop];
     });
     
     it(@"tracks Application Backgrounded", ^{

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Nielsen App SDK as of version 6.0.0.0 is compatible with iOS 8.0 and above.
 The Segment-Nielsen DTVR SDK is not available through [CocoaPods](http://cocoapods.org) trunk due to Nielsen's SDK being in a private spec repo. To install the Segment-Nielsen-DTVR pod, add the following line to your Podfile:
 
 ```ruby
-pod "Segment-Nielsen-DTVR", :git => 'https://github.com/segment-integrations/analytics-ios-integration-nielsen-dtvr.git', :tag => '1.0.0'
+pod "Segment-Nielsen-DTVR", :git => 'https://github.com/segment-integrations/analytics-ios-integration-nielsen-dtvr.git', :tag => '1.0.1'
 ```
 
 The integration relies on the Nielsen App SDK framework, which can either be installed via CocoaPods or by manually adding the framework.

--- a/Segment-Nielsen-DTVR.podspec
+++ b/Segment-Nielsen-DTVR.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name          = 'Segment-Nielsen-DTVR'
-    s.version       = '1.0.0'
+    s.version       = '1.0.1'
     s.summary       = 'Nielsen DTVR Integration for Segment'
     
     s.description   = <<-DESC

--- a/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegration.m
+++ b/Segment-Nielsen-DTVR/Classes/SEGNielsenDTVRIntegration.m
@@ -142,19 +142,13 @@
                                                             @"Video Playback Buffer Started",
                                                             @"Video Playback Seek Started",
                                                             @"Video Content Completed",
-                                                            @"Application Backgrounded"
+                                                            @"Application Backgrounded",
+                                                            @"Video Playback Completed",
+                                                            @"Video Playback Exited"
                                                             ]
                                            withHandler:^(NielsenAppApi *nielsen, SEGTrackPayload *payload) {
                                                [nielsen stop];
                                            }];
-    
-    SEGNielsenEventHandler *endHandler = [[SEGNielsenEventHandler alloc]
-                                          initWithEvents:@[
-                                                           @"Video Playback Completed"
-                                                           ]
-                                          withHandler:^(NielsenAppApi *nielsen, SEGTrackPayload *payload) {
-                                              [nielsen end];
-                                          }];
     
     // This is marked as required in the destination settings
     NSArray<NSString *> *sendID3EventNames = self.settings[@"sendId3Events"] ?: @[];
@@ -174,7 +168,6 @@
                            startHandler,
                            playHandler,
                            stopHandler,
-                           endHandler,
                            sendID3Handler
                            ];
 }


### PR DESCRIPTION
Nielsen has requested we remove any mappings to `end`. Instead, Video Playback Completed should be mapped to `stop`.

Additionally, Fox has requested a new event for Video Playback Exited be added to our spec. This has been approved by the spec committee. See here: https://paper.dropbox.com/doc/Video-Spec-Event-Proposal-for-Video-Playback-Exited--A8j5DFZuVoZYlsG~ZQr96tlcAg-rUDm4tQEB1RsdH0R7Xujm. Nielsen has recommended mapping this new event to their `stop` method as well.

Unit tests and local tests in progress.